### PR TITLE
Implement checksum headers and adjust chunking

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,32 @@
+# LockerCloud Synchronization Protocol
+
+This document describes the protocol used for communication between the client and server components of the LockerCloud application. It is inspired by HTTP and uses a simple message format consisting of a start line, headers and an optional body.
+
+## Commands
+
+| Method | Path         | Purpose                       |
+|-------|--------------|-------------------------------|
+| GET    | `/download`  | Download a file. Requires query parameter `fileName`. |
+| POST   | `/upload`    | Upload a file. Large files can be sent in chunks using the headers described below. |
+| POST   | `/sync`      | Request file synchronization. |
+| POST   | `/listFiles` | Retrieve the list of files on the server. |
+| DELETE | `/delete`    | Delete a file. Requires query parameter `fileName`. |
+
+## Headers
+
+* `Content-Length` – length of the request body in bytes.
+* `Content-Disposition` – for uploads, indicates the original file name.
+* `Checksum` – MD5 checksum used to validate an uploaded file or download response.
+* `Chunk-Index` – (optional) index of the uploaded chunk starting at 1.
+* `Chunk-Total` – (optional) total number of chunks for the file.
+* `File-Checksum` – (optional) final checksum of the whole file, sent with the last chunk.
+* `Host` – hostname of the server.
+
+## Large File Handling
+
+Files larger than **4 GB** are uploaded in chunks. Each chunk is sent in a separate `POST /upload` request. The server stores chunks as `<filename>.partN` and assembles them once the last chunk is received. The final file is validated using `File-Checksum`.
+
+## Network Failure Recovery
+
+The server retries upload and download operations up to three times in case of I/O errors. If a transactional upload with a checksum is requested, the file is only committed when the checksum matches.
+

--- a/src/main/java/org/soprasteria/avans/lockercloud/service/FileManagerService.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/service/FileManagerService.java
@@ -25,8 +25,8 @@ import java.util.stream.Stream;
 @Service
 public class FileManagerService {
 
-    // Voor grote bestanden (demonstratie: 100 MB threshold, in productie 4GB)
-    private static final long CHUNK_THRESHOLD = 100 * 1024 * 1024; // 100 MB
+    // Voor grote bestanden groter dan 4GB wordt chunking toegepast
+    private static final long CHUNK_THRESHOLD = 4L * 1024 * 1024 * 1024; // 4 GB
     private static final long CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB
 
     private final Path storageLocation = Paths.get("filestorage");
@@ -343,6 +343,22 @@ public class FileManagerService {
         }
     }
 
+    // Publieke helper voor het berekenen van een MD5-checksum van een bytearray
+    public String calculateChecksum(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(data);
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("MD5 algorithm not found", e);
+        }
+    }
+
     /**
      * Automatische synchronisatie: Lees de "clientSync" map (simuleert de lokale client-bestanden),
      * bereken metadata voor elk bestand en roep de bestaande syncFiles-methode aan.
@@ -402,6 +418,93 @@ public class FileManagerService {
                  System.err.println("Failed to delete temp file " + tempPath + " during transactional save error handling.");
             }
             throw new FileStorageException("Failed transactional save for " + normalizedFileName, e);
+        }
+    }
+
+    @Retryable(value = { IOException.class }, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+    public void saveFileTransactionalWithRetry(MultipartFile file, String expectedChecksum) {
+        saveFileTransactional(file, expectedChecksum);
+    }
+
+    @Recover
+    public void recoverSaveFileTransactional(IOException e, MultipartFile file, String expectedChecksum) {
+        String fileName = file.getOriginalFilename();
+        if (fileName != null) {
+            deleteFileChunks(fileName);
+            try {
+                Files.deleteIfExists(storageLocation.resolve(fileName));
+            } catch (IOException ex) {
+                System.err.println("Failed to delete main file during recovery:" + fileName);
+            }
+        }
+        throw new FileStorageException("Failed to upload file '" + fileName + "' after retries.", e);
+    }
+
+    @Retryable(value = { IOException.class }, maxAttempts = 3, backoff = @Backoff(delay = 2000))
+    public void saveFileChunkWithRetry(MultipartFile chunk, int chunkIndex, int chunkTotal,
+                                       String chunkChecksum, String finalChecksum) {
+        saveFileChunk(chunk, chunkIndex, chunkTotal, chunkChecksum, finalChecksum);
+    }
+
+    @Recover
+    public void recoverSaveFileChunk(IOException e, MultipartFile chunk, int chunkIndex, int chunkTotal,
+                                     String chunkChecksum, String finalChecksum) {
+        String fileName = chunk.getOriginalFilename();
+        if (fileName != null) {
+            deleteFileChunks(fileName);
+        }
+        throw new FileStorageException("Failed to upload chunk " + chunkIndex + " of '" + fileName + "'", e);
+    }
+
+    private void saveFileChunk(MultipartFile chunk, int index, int total,
+                               String chunkChecksum, String finalChecksum) {
+        String originalFileName = chunk.getOriginalFilename();
+        if (originalFileName == null || originalFileName.trim().isEmpty()) {
+            throw new FileStorageException("File name missing for chunk upload.");
+        }
+        String normalized = Paths.get(originalFileName).getFileName().toString();
+        try {
+            if (chunkChecksum != null) {
+                try (InputStream in = chunk.getInputStream()) {
+                    String actual = calculateChecksum(in);
+                    if (!actual.equalsIgnoreCase(chunkChecksum)) {
+                        throw new FileStorageException("Checksum mismatch for chunk " + index + " of " + normalized);
+                    }
+                }
+            }
+
+            Path chunkPath = storageLocation.resolve(normalized + ".part" + index);
+            try (InputStream in = chunk.getInputStream()) {
+                Files.copy(in, chunkPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            if (index == total) {
+                assembleChunks(normalized, total, finalChecksum);
+            }
+        } catch (IOException e) {
+            throw new FileStorageException("Error saving chunk " + index + " of " + normalized, e);
+        }
+    }
+
+    private void assembleChunks(String fileName, int total, String expectedChecksum) throws IOException {
+        Path finalPath = storageLocation.resolve(fileName);
+        try (OutputStream out = Files.newOutputStream(finalPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            for (int i = 1; i <= total; i++) {
+                Path part = storageLocation.resolve(fileName + ".part" + i);
+                Files.copy(part, out);
+            }
+        }
+
+        if (expectedChecksum != null) {
+            String actual = calculateChecksum(finalPath);
+            if (!actual.equalsIgnoreCase(expectedChecksum)) {
+                Files.deleteIfExists(finalPath);
+                throw new FileStorageException("Final checksum mismatch for " + fileName);
+            }
+        }
+
+        for (int i = 1; i <= total; i++) {
+            Files.deleteIfExists(storageLocation.resolve(fileName + ".part" + i));
         }
     }
 

--- a/src/test/java/org/soprasteria/avans/lockercloud/controller/FileControllerTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/controller/FileControllerTest.java
@@ -42,7 +42,7 @@ class FileControllerTest {
         MultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "data".getBytes());
         RedirectAttributes attrs = new RedirectAttributesModelMap();
 
-        String view = controller.uploadFile(file, attrs);
+        String view = controller.uploadFile(file, null, null, null, null, attrs);
 
         assertEquals("redirect:/", view);
         assertTrue(attrs.getFlashAttributes().containsKey("uploadSuccess"));
@@ -56,7 +56,7 @@ class FileControllerTest {
         doThrow(new RuntimeException("oops")).when(fileManagerService).saveFileWithRetry(file);
         RedirectAttributes attrs = new RedirectAttributesModelMap();
 
-        String view = controller.uploadFile(file, attrs);
+        String view = controller.uploadFile(file, null, null, null, null, attrs);
 
         assertEquals("redirect:/", view);
         assertTrue(attrs.getFlashAttributes().containsKey("uploadError"));
@@ -67,13 +67,17 @@ class FileControllerTest {
     @Test
     void downloadFile_success() throws Exception {
         byte[] data = {1,2,3};
+        String checksum = md5(data);
         when(fileManagerService.getFile("f.bin")).thenReturn(data);
+        when(fileManagerService.calculateChecksum(data)).thenReturn(checksum);
 
         ResponseEntity<byte[]> resp = controller.downloadFile("f.bin");
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
         assertEquals("attachment; filename=\"f.bin\"", resp.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION));
+        assertEquals(checksum, resp.getHeaders().getFirst("Checksum"));
         assertEquals(MediaType.APPLICATION_OCTET_STREAM, resp.getHeaders().getContentType());
+        assertEquals(data.length, resp.getHeaders().getContentLength());
         assertArrayEquals(data, resp.getBody());
     }
 
@@ -230,5 +234,14 @@ class FileControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertEquals("Error syncing files: sync fail", resp.getBody());
+    }
+
+    private String md5(byte[] data) throws Exception {
+        var md = java.security.MessageDigest.getInstance("MD5");
+        md.update(data);
+        byte[] digest = md.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) sb.append(String.format("%02x", b));
+        return sb.toString();
     }
 }

--- a/src/test/java/org/soprasteria/avans/lockercloud/service/FileManagerServiceTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/service/FileManagerServiceTest.java
@@ -74,8 +74,8 @@ class FileManagerServiceTest {
         byte[] data = "chunk".getBytes();
         MultipartFile raw = new MockMultipartFile("file", "big.bin", "application/octet-stream", data);
         MultipartFile file = spy(raw);
-        // threshold is 100MB
-        long threshold = 100L * 1024 * 1024;
+        // threshold is 4GB
+        long threshold = 4L * 1024 * 1024 * 1024;
         when(file.getSize()).thenReturn(threshold + 1);
 
         service.saveFile(file);


### PR DESCRIPTION
## Summary
- support checksum header on file upload and download
- add transactional upload with retries
- expose checksum calculation helper
- set chunking threshold to 4GB and update tests
- adapt tests for new API behavior
- document protocol

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684003d36370832d977c81ea4ad540be