### PR TITLE
Add SSL server shutdown improvements

### DIFF
--- a/src/main/java/org/soprasteria/avans/lockercloud/syncserver/ServerBootstrap.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/syncserver/ServerBootstrap.java
@@ -1,0 +1,26 @@
+package org.soprasteria.avans.lockercloud.syncserver;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Bootstrap class to start the {@link SslSyncServer} from command line.
+ */
+public class ServerBootstrap {
+    public static void main(String[] args) throws Exception {
+        int port = 8443;
+        for (String arg : args) {
+            if (arg.startsWith("--server.port=")) {
+                port = Integer.parseInt(arg.substring("--server.port=".length()));
+            }
+        }
+        port = Integer.parseInt(System.getProperty("server.port", String.valueOf(port)));
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        SslSyncServer server = new SslSyncServer(port, executor);
+        server.start();
+        System.out.println("PORT:" + server.getPort());
+        while (server.isRunning()) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/src/main/java/org/soprasteria/avans/lockercloud/syncserver/SslSyncServer.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/syncserver/SslSyncServer.java
@@ -1,0 +1,168 @@
+package org.soprasteria.avans.lockercloud.syncserver;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple SSL server that accepts connections and echoes back the first line sent by the client.
+ * Provides start/stop/isRunning API and performs graceful shutdown of resources.
+ */
+public class SslSyncServer {
+    private static final Logger logger = LoggerFactory.getLogger(SslSyncServer.class);
+
+    private final int port;
+    private final ExecutorService executorService;
+    private SSLServerSocket serverSocket;
+    private Thread acceptThread;
+    private Thread shutdownHook;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public SslSyncServer(int port, ExecutorService executorService) {
+        this.port = port;
+        this.executorService = executorService;
+    }
+
+    public synchronized void start() throws Exception {
+        if (running.get()) {
+            return;
+        }
+        SSLServerSocketFactory factory = createSSLServerSocketFactory();
+        serverSocket = (SSLServerSocket) factory.createServerSocket(port);
+        acceptThread = new Thread(this::acceptLoop, "accept-thread");
+        shutdownHook = new Thread(() -> {
+            try {
+                stop();
+            } catch (Exception e) {
+                logger.error("Error during shutdown", e);
+            }
+        }, "shutdown-hook");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+        running.set(true);
+        acceptThread.start();
+    }
+
+    private void acceptLoop() {
+        while (running.get()) {
+            try {
+                Socket socket = serverSocket.accept();
+                executorService.submit(new ClientHandler((SSLSocket) socket));
+            } catch (IOException e) {
+                if (running.get()) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public synchronized void stop() {
+        if (!running.getAndSet(false)) {
+            return;
+        }
+        if (shutdownHook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException ignore) {
+                // JVM is already shutting down
+            }
+        }
+
+        try {
+            if (serverSocket != null && !serverSocket.isClosed()) {
+                serverSocket.close();
+            }
+        } catch (IOException e) {
+            logger.error("Error closing server socket", e);
+        }
+
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+
+        if (acceptThread != null) {
+            try {
+                acceptThread.join(TimeUnit.SECONDS.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    public int getPort() {
+        if (serverSocket != null) {
+            return serverSocket.getLocalPort();
+        }
+        return -1;
+    }
+
+    private SSLServerSocketFactory createSSLServerSocketFactory() throws Exception {
+        String keyStorePath = System.getProperty("javax.net.ssl.keyStore");
+        String password = System.getProperty("javax.net.ssl.keyStorePassword");
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        try (InputStream in = new FileInputStream(keyStorePath)) {
+            keyStore.load(in, password.toCharArray());
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, password.toCharArray());
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(kmf.getKeyManagers(), null, null);
+        return context.getServerSocketFactory();
+    }
+
+    private static class ClientHandler implements Runnable {
+        private final SSLSocket socket;
+
+        ClientHandler(SSLSocket socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public void run() {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()))) {
+                String line = reader.readLine();
+                if (line != null) {
+                    writer.write("ACK:" + line + "\n");
+                    writer.flush();
+                }
+            } catch (IOException e) {
+                // log and continue
+                e.printStackTrace();
+            } finally {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/soprasteria/avans/lockercloud/syncserver/KeyStoreTestUtils.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/syncserver/KeyStoreTestUtils.java
@@ -1,0 +1,39 @@
+package org.soprasteria.avans.lockercloud.syncserver;
+
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+/** Utility class for generating an in-memory keystore for SSL tests. */
+public final class KeyStoreTestUtils {
+    private KeyStoreTestUtils() {}
+
+    /**
+     * Creates a temporary JKS keystore containing a single self-signed certificate.
+     *
+     * @param password the password for the keystore
+     * @return path to the created keystore file
+     */
+    public static Path createTempKeyStore(String password) throws Exception {
+        Path file = Files.createTempFile("test-keystore", ".jks");
+
+        CertAndKeyGen gen = new CertAndKeyGen("RSA", "SHA256withRSA");
+        gen.generate(2048);
+        X509Certificate cert = gen.getSelfCertificate(new X500Name("CN=Test"), 365 * 24L * 60L * 60L);
+
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+        ks.setKeyEntry("alias", gen.getPrivateKey(), password.toCharArray(), new Certificate[]{cert});
+
+        try (OutputStream out = Files.newOutputStream(file)) {
+            ks.store(out, password.toCharArray());
+        }
+        return file;
+    }
+}

--- a/src/test/java/org/soprasteria/avans/lockercloud/syncserver/ServerBootstrapIT.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/syncserver/ServerBootstrapIT.java
@@ -1,0 +1,54 @@
+package org.soprasteria.avans.lockercloud.syncserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.soprasteria.avans.lockercloud.syncserver.KeyStoreTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServerBootstrapIT {
+
+    @Test
+    void shutdownHookCleansResourcesOnSigInt() throws Exception {
+        Path keyStore = KeyStoreTestUtils.createTempKeyStore("password");
+        String classpath = System.getProperty("java.class.path");
+        ProcessBuilder pb = new ProcessBuilder(
+                "java",
+                "-Djavax.net.ssl.keyStore=" + keyStore.toAbsolutePath(),
+                "-Djavax.net.ssl.keyStorePassword=password",
+                "-Djavax.net.ssl.trustStore=" + keyStore.toAbsolutePath(),
+                "-Djavax.net.ssl.trustStorePassword=password",
+                "-cp", classpath,
+                "org.soprasteria.avans.lockercloud.syncserver.ServerBootstrap",
+                "--server.port=0"
+        );
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+        String line;
+        int port = -1;
+        long end = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < end && (line = reader.readLine()) != null) {
+            if (line.startsWith("PORT:")) {
+                port = Integer.parseInt(line.substring(5));
+                break;
+            }
+        }
+        assertTrue(port > 0);
+
+        new ProcessBuilder("kill", "-SIGINT", String.valueOf(process.pid())).start().waitFor(5, TimeUnit.SECONDS);
+        boolean exited = process.waitFor(10, TimeUnit.SECONDS);
+        assertTrue(exited);
+
+        try (var socket = new java.net.Socket("localhost", port)) {
+            fail("Should not connect after SIGINT");
+        } catch (Exception expected) {
+            // ignore
+        }
+    }
+}

--- a/src/test/java/org/soprasteria/avans/lockercloud/syncserver/SslSyncServerTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/syncserver/SslSyncServerTest.java
@@ -1,0 +1,73 @@
+package org.soprasteria.avans.lockercloud.syncserver;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.BufferedWriter;
+import java.net.ConnectException;
+import java.net.Socket;
+import java.nio.file.Path;
+
+// Utility for generating temporary keystores
+import org.soprasteria.avans.lockercloud.syncserver.KeyStoreTestUtils;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SslSyncServerTest {
+
+    private static Path KEYSTORE;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        KEYSTORE = KeyStoreTestUtils.createTempKeyStore("password");
+        System.setProperty("javax.net.ssl.keyStore", KEYSTORE.toAbsolutePath().toString());
+        System.setProperty("javax.net.ssl.keyStorePassword", "password");
+        System.setProperty("javax.net.ssl.trustStore", KEYSTORE.toAbsolutePath().toString());
+        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        System.clearProperty("javax.net.ssl.keyStore");
+        System.clearProperty("javax.net.ssl.keyStorePassword");
+        System.clearProperty("javax.net.ssl.trustStore");
+        System.clearProperty("javax.net.ssl.trustStorePassword");
+    }
+
+    @Test
+    void connectionsRejectedAfterStop() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        SslSyncServer server = new SslSyncServer(0, executor);
+        server.start();
+        int port = server.getPort();
+
+        SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
+             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+            writer.write("hello\n");
+            writer.flush();
+            assertEquals("ACK:hello", reader.readLine());
+        }
+
+        server.stop();
+        assertFalse(server.isRunning());
+
+        assertThrows(ConnectException.class, () -> {
+            Socket s = factory.createSocket("localhost", port);
+            s.close();
+        });
+
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor SslSyncServer to use a shutdown hook thread and wait for accept thread
- parse `--server.port` command line argument in ServerBootstrap
- generate self-signed keystores in tests
- remove binary keystore from repo

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684371b1fb10832d865b96d1d260853b