### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+---
+name: Pull Request
+about: Submit changes for review
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Summary
+Describe the goals of this PR and the changes made.
+
+## Related Issue(s)
+<!-- List related issues. Use closing keywords if appropriate. -->
+
+## Changes
+- 
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] Documentation updated if applicable
+- [ ] Code follows the project's style guidelines


### PR DESCRIPTION
## Summary
- add a default pull request template for contributor guidance

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843745f9b18832d8f44af0d1118e735