### PR TITLE
Use SSL socket for all operations

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,6 +1,6 @@
 # LockerCloud Socket Protocol
 
-LockerCloud communicates over an SSL socket on port `9000`. Each command is sent as an ASCII line followed by optional binary data. The server replies with `OK`, `ERR` or the requested bytes.
+LockerCloud communicates over an SSL socket on port `9000`. **This port does not speak HTTP.** Each command is sent as an ASCII line followed by optional binary data. The server replies with `OK`, `ERR` or the requested bytes.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ to verify that commands were received.
 HTTP controllers are **disabled** unless the `http` Spring profile is active.
 If you want to use the web interface or REST API, set the environment variable
 `SPRING_PROFILES_ACTIVE` to include `http` (for example `prod,http`). The
-provided `docker-compose.yml` sets this variable to `prod` only, so by default
-the socket server is the only available interface.
+provided `docker-compose.yml` enables the web interface by default using
+`SPRING_PROFILES_ACTIVE=prod,http`. Set it to `prod` only if you want to run
+exclusively over the socket server.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,17 @@ DELETE <filename>\n
 LIST\n
 ```
 
-The server responds with `OK` or the requested data. Enable application logging
-to verify that commands were received.
+The server responds with `OK` or the requested data. **Port `9000` does not
+implement HTTP**, so accessing it from a browser will fail with a TLS error.
+Use an SSL-capable client such as `openssl`:
+
+```bash
+openssl s_client -connect localhost:9000 -quiet <<'EOF'
+LIST
+EOF
+```
+
+Enable application logging to verify that commands were received.
 
 HTTP controllers are **disabled** unless the `http` Spring profile is active.
 If you want to use the web interface or REST API, set the environment variable

--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ podman compose up --build
 ```
 The compose file mounts `keystore.p12` into the container at startup. Ensure the
 file is present in the project root (or adjust `SSL_KEYSTORE` accordingly).
+
 ## SSL Socket Server
 
-The application also starts an SSL socket server on port `9000` at runtime. This server exposes simple commands for file upload, download, listing and deletion without using HTTP. Each connection accepts a single command in the form:
+All file operations are performed over a raw SSL socket on port `9000`. The
+server implements the commands described in [PROTOCOL.md](PROTOCOL.md). Connect
+using `openssl s_client` or any SSL capable socket library and send one of the
+following commands:
 
 ```
 UPLOAD <filename> <length>\n<bytes...>
@@ -44,6 +48,6 @@ DELETE <filename>\n
 LIST\n
 ```
 
-Responses are plain text or raw bytes. The server uses the same `keystore.p12` for TLS encryption.
-
-YourPasswordHere = password;
+The server responds with `OK` or the requested data. Enable application logging
+to verify that commands were received. HTTP endpoints are disabled by default;
+set `spring.profiles.active=http` if you wish to use the legacy MVC layer.

--- a/README.md
+++ b/README.md
@@ -52,5 +52,10 @@ LIST\n
 ```
 
 The server responds with `OK` or the requested data. Enable application logging
-to verify that commands were received. HTTP endpoints are disabled by default;
-set `spring.profiles.active=http` if you wish to use the legacy MVC layer.
+to verify that commands were received.
+
+HTTP controllers are **disabled** unless the `http` Spring profile is active.
+If you want to use the web interface or REST API, set the environment variable
+`SPRING_PROFILES_ACTIVE` to include `http` (for example `prod,http`). The
+provided `docker-compose.yml` sets this variable to `prod` only, so by default
+the socket server is the only available interface.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ The application exposes HTTPS on port `8443`. Provide a PKCS#12 keystore named
 variable to its location) before running the application. The relevant
 configuration is in `src/main/resources/application.properties`.
 
-When running in Docker, the container also exposes port `8443` for secure
-connections. WebSocket connections should use the `wss://` protocol when the
-server is accessed via HTTPS.
+When running in Docker, the container exposes ports `8443` (HTTPS) and `9000`
+for the socket server. WebSocket connections should use the `wss://` protocol
+when the server is accessed via HTTPS. Set the `KEYSTORE_PASSWORD` environment
+variable to the keystore's password.
 
 ### Generating a certificate
 
@@ -31,8 +32,10 @@ After creating the keystore, build the project and start the container
 mvn clean package
 podman compose up --build
 ```
-The compose file mounts `keystore.p12` into the container at startup. Ensure the
-file is present in the project root (or adjust `SSL_KEYSTORE` accordingly).
+The compose file mounts `keystore.p12` into the container at startup. It exposes
+ports `8443` and `9000` and expects the environment variable
+`KEYSTORE_PASSWORD` to match the keystore password. Ensure the file is present
+in the project root (or adjust `SSL_KEYSTORE` accordingly).
 
 ## SSL Socket Server
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Enable application logging to verify that commands were received.
 HTTP controllers are **disabled** unless the `http` Spring profile is active.
 If you want to use the web interface or REST API, set the environment variable
 `SPRING_PROFILES_ACTIVE` to include `http` (for example `prod,http`). The
-provided `docker-compose.yml` enables the web interface by default using
-`SPRING_PROFILES_ACTIVE=prod,http`. Set it to `prod` only if you want to run
-exclusively over the socket server.
+provided `docker-compose.yml` runs the application using only the socket server
+by default (`SPRING_PROFILES_ACTIVE=prod`). Add `http` if you need the web
+interface.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - "8443:8443"
       - "9000:9000"
     environment:
-      # Include the 'http' profile if you want to enable the web interface
-      - SPRING_PROFILES_ACTIVE=prod,http
+      # HTTP controllers are disabled by default; add 'http' to enable them
+      - SPRING_PROFILES_ACTIVE=prod
       - KEYSTORE_PASSWORD=changeit
     volumes:
       - ./filestorage:/app/filestorage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       - "8443:8443"
       - "9000:9000"
     environment:
-      - SPRING_PROFILES_ACTIVE=prod
+      # Include the 'http' profile if you want to enable the web interface
+      - SPRING_PROFILES_ACTIVE=prod,http
       - KEYSTORE_PASSWORD=changeit
     volumes:
       - ./filestorage:/app/filestorage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
     container_name: lockercloud_app
     ports:
       - "8443:8443"
+      - "9000:9000"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - KEYSTORE_PASSWORD=changeit
     volumes:
       - ./filestorage:/app/filestorage
       - ./keystore.p12:/app/keystore.p12:ro

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
@@ -69,7 +69,8 @@ public class FileController {
             } else if (checksum != null && !checksum.isBlank()) {
                 fileManagerService.saveFileTransactionalWithRetry(file, checksum);
             } else {
-                fileManagerService.saveFileWithRetry(file);
+                // Call overload with expectedChecksum=null when no checksum header provided
+                fileManagerService.saveFileWithRetry(file, null);
             }
             redirectAttributes.addFlashAttribute(
               "uploadSuccess",

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
@@ -47,10 +47,6 @@ public class FileController {
         this.fileManagerService = fileManagerService;
     }
 
-    @GetMapping("/")
-    public String index() {
-        return "index";
-    }
 
     @Operation(summary = "Upload a file", description = "Uploads a file to the server")
     @ApiResponse(responseCode = "200", description = "File uploaded successfully")

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/FileController.java
@@ -7,6 +7,7 @@ import org.soprasteria.avans.lockercloud.dto.SyncResult;
 import org.soprasteria.avans.lockercloud.exception.FileStorageException;
 import org.soprasteria.avans.lockercloud.model.FileMetadata;
 import org.soprasteria.avans.lockercloud.service.FileManagerService;
+import org.springframework.context.annotation.Profile;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Controller
+@Profile("http")
 @RequestMapping
 @Tag(name = "File Operations", description = "Endpoints for file upload, download, deletion, listing and synchronization")
 public class FileController {

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/FileViewController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/FileViewController.java
@@ -2,10 +2,12 @@ package org.soprasteria.avans.lockercloud.controller;
 
 import org.soprasteria.avans.lockercloud.service.FileManagerService;
 import org.springframework.stereotype.Controller;
+import org.springframework.context.annotation.Profile;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
+@Profile("http")
 public class FileViewController {
 
     private final FileManagerService fileManagerService;

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/HomeController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/HomeController.java
@@ -2,10 +2,12 @@ package org.soprasteria.avans.lockercloud.controller;
 
 import org.soprasteria.avans.lockercloud.service.FileManagerService;
 import org.springframework.stereotype.Controller;
+import org.springframework.context.annotation.Profile;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
+@Profile("http")
 public class HomeController {
 
 

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/SyncController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/SyncController.java
@@ -5,10 +5,12 @@ import org.soprasteria.avans.lockercloud.dto.SyncResult;
 import org.soprasteria.avans.lockercloud.service.FileManagerService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.context.annotation.Profile;
 
 import java.util.concurrent.CompletableFuture;
 
 @RestController
+@Profile("http")
 public class SyncController {
 
     private final FileManagerService fileManagerService;

--- a/src/main/java/org/soprasteria/avans/lockercloud/controller/ViewController.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/controller/ViewController.java
@@ -2,11 +2,13 @@ package org.soprasteria.avans.lockercloud.controller;
 
 import org.soprasteria.avans.lockercloud.service.FileManagerService;
 import org.springframework.stereotype.Controller;
+import org.springframework.context.annotation.Profile;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@Profile("http")
 @RequestMapping("/view")
 public class ViewController {
 

--- a/src/main/java/org/soprasteria/avans/lockercloud/service/FileManagerService.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/service/FileManagerService.java
@@ -30,11 +30,9 @@ public class FileManagerService {
 
     // Voor grote bestanden groter dan 4GB wordt chunking toegepast
     private static final long CHUNK_THRESHOLD = 4L * 1024 * 1024 * 1024; // 4 GB
-    private static final long CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB
+    private static final long CHUNK_SIZE = 10L * 1024 * 1024; // 10 MB
     private static final Logger logger = LoggerFactory.getLogger(FileManagerService.class);
     // Bestanden groter dan 4GB moeten in chunks worden verwerkt volgens het protocol
-    private static final long CHUNK_THRESHOLD = 4L * 1024 * 1024 * 1024; // 4 GB
-    private static final long CHUNK_SIZE = 10L * 1024 * 1024; // 10 MB
     private static final long MOD_TIME_THRESHOLD_MS = 1000L;
 
     private final Path storageLocation = Paths.get("filestorage");
@@ -339,6 +337,18 @@ public class FileManagerService {
         } catch (NoSuchAlgorithmException e) {
             throw new IOException("MD5 algorithm not found", e);
         }
+    }
+
+    /**
+     * Utility method to convert a byte array into a hexadecimal string.
+     * This mirrors the helper used in {@link org.soprasteria.avans.lockercloud.controller.FileController}.
+     */
+    private String bytesToHex(byte[] digest) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
     }
 
     // Overload voor InputStream

--- a/src/main/java/org/soprasteria/avans/lockercloud/socket/SSLFileServer.java
+++ b/src/main/java/org/soprasteria/avans/lockercloud/socket/SSLFileServer.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class SSLFileServer implements Runnable {
 
     private final int port;
+    private volatile int boundPort = -1;
     private final FileManagerService fileService;
     private final String keyStorePath;
     private final String keyStorePassword;
@@ -36,6 +37,7 @@ public class SSLFileServer implements Runnable {
             SSLContext ctx = createContext();
             SSLServerSocketFactory factory = ctx.getServerSocketFactory();
             try (SSLServerSocket serverSocket = (SSLServerSocket) factory.createServerSocket(port)) {
+                boundPort = serverSocket.getLocalPort();
                 while (true) {
                     SSLSocket socket = (SSLSocket) serverSocket.accept();
                     handle(socket);
@@ -44,6 +46,10 @@ public class SSLFileServer implements Runnable {
         } catch (Exception e) {
             throw new RuntimeException("SSL socket server failed", e);
         }
+    }
+
+    public int getPort() {
+        return boundPort;
     }
 
     private SSLContext createContext() throws Exception {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ server.port=8443
 server.ssl.enabled=true
 server.ssl.key-store=${SSL_KEYSTORE:file:keystore.p12}
 # Path to PKCS#12 keystore mounted alongside the jar
-server.ssl.key-store-password=YourPasswordHere
+server.ssl.key-store-password=${KEYSTORE_PASSWORD}
 server.ssl.key-store-type=PKCS12
 server.ssl.key-alias=lockercloud
 

--- a/src/test/java/org/soprasteria/avans/lockercloud/controller/FileControllerTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/controller/FileControllerTest.java
@@ -33,11 +33,6 @@ class FileControllerTest {
     }
 
     @Test
-    void index_returnsIndexView() {
-        assertEquals("index", controller.index());
-    }
-
-    @Test
     void uploadFile_success() {
         MultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "data".getBytes());
         RedirectAttributes attrs = new RedirectAttributesModelMap();

--- a/src/test/java/org/soprasteria/avans/lockercloud/service/NetworkFaultIntegrationTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/service/NetworkFaultIntegrationTest.java
@@ -48,7 +48,7 @@ class NetworkFaultIntegrationTest {
                 1,
                 3); // drop after 3 bytes on first attempt
 
-        service.saveFileWithRetry(file);
+        service.saveFileWithRetry(file, null);
 
         assertEquals(2, file.getAttemptCount(), "Should retry once");
         Path target = storageDir.resolve("net.txt");
@@ -81,7 +81,7 @@ class NetworkFaultIntegrationTest {
                 2,
                 chunkSize / 2); // fail twice
 
-        service.saveFileWithRetry(file);
+        service.saveFileWithRetry(file, null);
 
         assertEquals(3, file.getAttemptCount());
         Path target = storageDir.resolve("big.bin");
@@ -102,7 +102,7 @@ class NetworkFaultIntegrationTest {
             String name = Thread.currentThread().getName() + ".txt";
             Supplier<InputStream> sup = () -> new java.io.ByteArrayInputStream(data);
             FaultyMultipartFile f = new FaultyMultipartFile("f", name, "text/plain", sup, data.length, 1, 2);
-            service.saveFileWithRetry(f);
+            service.saveFileWithRetry(f, null);
             return null;
         };
 

--- a/src/test/java/org/soprasteria/avans/lockercloud/socket/SSLFileServerIntegrationTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/socket/SSLFileServerIntegrationTest.java
@@ -1,0 +1,107 @@
+package org.soprasteria.avans.lockercloud.socket;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.soprasteria.avans.lockercloud.service.FileManagerService;
+import org.soprasteria.avans.lockercloud.syncserver.KeyStoreTestUtils;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.*;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SSLFileServerIntegrationTest {
+
+    private static Path KEYSTORE;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        KEYSTORE = KeyStoreTestUtils.createTempKeyStore("password");
+        System.setProperty("javax.net.ssl.keyStore", KEYSTORE.toAbsolutePath().toString());
+        System.setProperty("javax.net.ssl.keyStorePassword", "password");
+        System.setProperty("javax.net.ssl.trustStore", KEYSTORE.toAbsolutePath().toString());
+        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        System.clearProperty("javax.net.ssl.keyStore");
+        System.clearProperty("javax.net.ssl.keyStorePassword");
+        System.clearProperty("javax.net.ssl.trustStore");
+        System.clearProperty("javax.net.ssl.trustStorePassword");
+    }
+
+    @Test
+    void uploadDownloadListDelete() throws Exception {
+        FileManagerService service = new FileManagerService();
+        SSLFileServer server = new SSLFileServer(0, service,
+                KEYSTORE.toAbsolutePath().toString(), "password");
+        Thread t = new Thread(server);
+        t.setDaemon(true);
+        t.start();
+
+        // wait for server socket to open
+        Thread.sleep(500);
+        int port = service.listFiles().size(); // dummy to load class
+        port = getServerPort(server); // reflection trick
+
+        SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
+             DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+             DataInputStream in = new DataInputStream(socket.getInputStream())) {
+
+            byte[] data = "hello".getBytes();
+            out.writeBytes("UPLOAD test.txt " + data.length + "\n");
+            out.write(data);
+            out.flush();
+            assertEquals("OK", readLine(in));
+        }
+
+        try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
+             DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+             DataInputStream in = new DataInputStream(socket.getInputStream())) {
+
+            out.writeBytes("LIST\n");
+            assertEquals("test.txt", readLine(in));
+            assertEquals("END", readLine(in));
+        }
+
+        try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
+             DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+             DataInputStream in = new DataInputStream(socket.getInputStream())) {
+
+            out.writeBytes("DOWNLOAD test.txt\n");
+            int len = Integer.parseInt(readLine(in));
+            byte[] buf = new byte[len];
+            in.readFully(buf);
+            assertArrayEquals("hello".getBytes(), buf);
+        }
+
+        try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
+             DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+             DataInputStream in = new DataInputStream(socket.getInputStream())) {
+
+            out.writeBytes("DELETE test.txt\n");
+            assertEquals("OK", readLine(in));
+        }
+    }
+
+    private static String readLine(DataInputStream in) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            if (b == '\n') break;
+            baos.write(b);
+        }
+        return baos.toString("UTF-8");
+    }
+
+    private int getServerPort(SSLFileServer server) throws Exception {
+        java.lang.reflect.Field portField = SSLFileServer.class.getDeclaredField("port");
+        portField.setAccessible(true);
+        return portField.getInt(server);
+    }
+}

--- a/src/test/java/org/soprasteria/avans/lockercloud/socket/SSLFileServerIntegrationTest.java
+++ b/src/test/java/org/soprasteria/avans/lockercloud/socket/SSLFileServerIntegrationTest.java
@@ -45,8 +45,7 @@ public class SSLFileServerIntegrationTest {
 
         // wait for server socket to open
         Thread.sleep(500);
-        int port = service.listFiles().size(); // dummy to load class
-        port = getServerPort(server); // reflection trick
+        int port = server.getPort();
 
         SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
         try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost", port);
@@ -99,9 +98,4 @@ public class SSLFileServerIntegrationTest {
         return baos.toString("UTF-8");
     }
 
-    private int getServerPort(SSLFileServer server) throws Exception {
-        java.lang.reflect.Field portField = SSLFileServer.class.getDeclaredField("port");
-        portField.setAccessible(true);
-        return portField.getInt(server);
-    }
 }


### PR DESCRIPTION
## Summary
- remove duplicate chunk constants
- log socket commands for easier tracing
- disable MVC controllers unless `http` profile is enabled
- document SSL socket usage
- add basic integration test for `SSLFileServer`
- fix missing bytesToHex helper

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847d5fa3258832da4a9d863cbd2781f